### PR TITLE
Update endnotes

### DIFF
--- a/src/epub/text/endnotes.xhtml
+++ b/src/epub/text/endnotes.xhtml
@@ -16,10 +16,10 @@
 					<p><i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/813/alexander-teixeira-de-mattos">813</a></i>. By Maurice Leblanc. Translated by Alexander Teixeira de Mattos (Mills &amp; Boon). <a href="chapter-1.xhtml#noteref-2" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-3" epub:type="endnote">
-					<p><i epub:type="se:name.publication.book">The Exploits of Arsène Lupin</i>. By Maurice Leblanc. Translated by Alexander Teixeira de Mattos (Cassell). <span epub:type="z3998:roman">IV</span> The Escape of Arsène Lupin. <a href="chapter-2.xhtml#noteref-3" epub:type="backlink">↩</a></p>
+					<p><i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/george-morehead">The Extraordinary Adventures of Arsène Lupin, Gentleman-Burglar</a></i>. By Maurice Leblanc. Translated by George Morehead. <span epub:type="z3998:roman">III</span> The Escape of Arsène Lupin. <a href="chapter-2.xhtml#noteref-3" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-4" epub:type="endnote">
-					<p><i epub:type="se:name.publication.book">The Exploits of Arsène Lupin</i>. <span epub:type="z3998:roman">IX</span> Holmlock Shears arrives too late. <a href="chapter-2.xhtml#noteref-4" epub:type="backlink">↩</a></p>
+					<p><i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/the-extraordinary-adventures-of-arsene-lupin-gentleman-burglar/george-morehead">The Extraordinary Adventures of Arsène Lupin, Gentleman-Burglar</a></i>. <span epub:type="z3998:roman">IX</span> Herlock Sholmes arrives too late. <a href="chapter-2.xhtml#noteref-4" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-5" epub:type="endnote">
 					<p><i epub:type="se:name.publication.book">Arsène Lupin⁠—The Novel of the Play</i>. By Edgar Jepson and Maurice Leblanc (Mills &amp; Boon). <a href="chapter-10.xhtml#noteref-5" epub:type="backlink">↩</a></p>


### PR DESCRIPTION
As discussed in [another issue](https://github.com/standardebooks/maurice-leblanc_the-hollow-needle_alexander-teixeira-de-mattos/issues/2), this updates some book references in the endnotes to point to the Standard Ebooks editions.

Note that there is one reference to "Sherlock Holmes" that was left unchanged:
> All the Sherlock Holmeses in the world would not know what to make of the mystery[…]

Leblanc has made other deliberate references to "fictional character Sherlock Holmes" as opposed to "real-life detective Herlock Sholmes", and this appears to be the former.
